### PR TITLE
remove dependeny from opencast_nginx role

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,5 +13,3 @@ galaxy_info:
       versions:
         - 7
         - 8
-dependencies:
-  - elan.opencast_nginx


### PR DESCRIPTION
If we would remove this dependency, this role would also work out-of-the-box with the [simple_nginx_reverse_proxy](https://github.com/elan-ev/simple_nginx_reverse_proxy).