### PR TITLE
Fix certbot reload

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: Restart certbot
+- name: Enable certbot
   ansible.builtin.systemd:
     name: certbot-renew.timer
-    state: restarted
+    enabled: true
     daemon_reload: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,15 +8,18 @@
   ansible.builtin.package:
     name: certbot
 
-- name: Install certbot services
-  ansible.builtin.template:
-    src: '{{ item }}'
-    dest: /etc/systemd/system/{{ item }}
-    mode: '0644'
+# This task should remove custom service definitions created by previous version of this role.
+# Certbot package come with a renew service definitions itself, why not using it?
+# It will renew all registred certificates by default and does not limit us on some domains.
+# You can remove this task on later versions.
+- name: Remove custom certbot services definition
+  ansible.builtin.file:
+    path: '/etc/systemd/system/{{ item }}'
+    state: absent
   loop:
     - certbot-renew.service
     - certbot-renew.timer
-  notify: Restart certbot
+  notify: Enable certbot
 
 - name: Start certbot service
   ansible.builtin.service:

--- a/templates/certbot-renew.service
+++ b/templates/certbot-renew.service
@@ -1,7 +1,0 @@
-[Unit]
-Description=Certbot Renew
-
-[Service]
-Type=simple
-ExecStart=/usr/bin/certbot -a webroot --webroot-path /var/lib/nginx/ --agree-tos -m {{ opencast_letsencrypt_email }} -n certonly --domains {{ inventory_hostname }}
-ExecStopPost=-/bin/systemctl reload nginx.service

--- a/templates/certbot-renew.timer
+++ b/templates/certbot-renew.timer
@@ -1,8 +1,0 @@
-[Unit]
-Description=Certbot Renew Scheduling.
-
-[Timer]
-OnCalendar=*-*-* 01:30:00
-
-[Install]
-WantedBy=multi-user.target


### PR DESCRIPTION
Renew service should not be limited on one domain

Certbot take care of all registred certificates by default. We should make use of it and not override this behaviour.

This PR is based on #4 and should be merged in order. It also fixes #2.
