### PR TITLE
Certbot deploy-hook option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@ Role Variables
 --------------
 
 - `opencast_letsencrypt_email`
-    - Email address for Let's Encrypt account (_required_)
-	 - This is used by Let's Encrypt to send certificate expiration warnings if necessary.
+  - Email address for Let's Encrypt account (_required_)
+  - This is used by Let's Encrypt to send certificate expiration warnings if necessary.
+- `opencast_certbot_deploy_hook`
+  - Command to run after certbot has updated certificate. The value is optional.
+    Already created certificates will not be updated.
 
 Dependencies
 ------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,8 +28,8 @@
     enabled: true
 
 - name: Generate initial certificate
-  ansible.builtin.shell:
-    cmd: >
+  ansible.builtin.command:
+    cmd: >-
       certbot -n
       -a webroot
       --webroot-path /var/lib/nginx/
@@ -37,6 +37,7 @@
       -m {{ opencast_letsencrypt_email }}
       certonly
       --domains {{ inventory_hostname }}
+      {%if opencast_certbot_deploy_hook | default(None) != None %}--deploy-hook {{ opencast_certbot_deploy_hook }}{% endif %}
     creates: /etc/letsencrypt/live/{{ inventory_hostname }}/fullchain.pem
 
 - name: Look for Nginx configuration directory


### PR DESCRIPTION
Provide a option for certbot deploy-hook. Note: certificates created by a previous version of this role will not be updated with deploy-hook.