### PR TITLE
Ansible role properties renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This Ansible role configures TLS certificate renewal via certbot for Opencast.
 Role Variables
 --------------
 
-- `opencast_letsencrypt_email`
+- `opencast_certbot_letsencrypt_email`
   - Email address for Let's Encrypt account (_required_)
   - This is used by Let's Encrypt to send certificate expiration warnings if necessary.
 - `opencast_certbot_deploy_hook`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
+opencast_certbot_letsencrypt_email: None
+opencast_certbot_deploy_hook: None
 opencast_certbot_enable_epel: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+
+- name: Check Let's Encrypt email address is set
+  ansible.builtin.assert:
+    that: opencast_certbot_letsencrypt_email != None
+    fail_msg: 'Please set opencast_certbot_letsencrypt_email!'
+
 - name: Activate epel repository on RedHat systems
   ansible.builtin.package:
     name: epel-release
@@ -36,10 +42,10 @@
       -a webroot
       --webroot-path /var/lib/nginx/
       --agree-tos
-      -m {{ opencast_letsencrypt_email }}
+      -m {{ opencast_certbot_letsencrypt_email }}
       certonly
       --domains {{ inventory_hostname }}
-      {%if opencast_certbot_deploy_hook | default(None) != None %}--deploy-hook {{ opencast_certbot_deploy_hook }}{% endif %}
+      {%if opencast_certbot_deploy_hook != None %}--deploy-hook {{ opencast_certbot_deploy_hook }}{% endif %}
     creates: /etc/letsencrypt/live/{{ inventory_hostname }}/fullchain.pem
 
 - name: Look for Nginx configuration directory


### PR DESCRIPTION
It is usual to prefix Ansible roles properties with role name. This is a breaking change.