### PR TITLE
Fixed certificate renewal on Debian based systems

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,6 +2,6 @@
 
 - name: Enable certbot
   ansible.builtin.systemd:
-    name: certbot-renew.timer
+    name: "{{ 'certbot-renew.timer' if ansible_os_family == 'RedHat' else 'certbot.timer' }}"
     enabled: true
     daemon_reload: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
 
 - name: Start certbot service
   ansible.builtin.service:
-    name: certbot-renew.timer
+    name: "{{ 'certbot-renew.timer' if ansible_os_family == 'RedHat' else 'certbot.timer' }}"
     state: started
     enabled: true
 


### PR DESCRIPTION
Certbot certificte renewal systemd service and timer is called certbot on Debian based systems.